### PR TITLE
Add Documentation for native Option in Time-plugin

### DIFF
--- a/src/packages/time-plugin.md
+++ b/src/packages/time-plugin.md
@@ -97,6 +97,7 @@ const picker = new easepick.create({
 | [stepMinutes](#option-stepMinutes) | number | 5 | Step for minutes.
 | [stepSeconds](#option-stepSeconds) | number | 5 | Step for seconds.
 | [format12](#option-format12) | boolean | false | Display 12H time.
+| [native](#option-native) | boolean | false | This allows you to use input fields with the type=“time” instead of the select boxes
 
 ## Methods
 


### PR DESCRIPTION
This PR updates the documentation to include details about the native option for time selection when using the TimePlugin. By default, the TimePlugin uses custom select boxes for selecting hours and minutes. The native option allows users to switch to native HTML time input elements.